### PR TITLE
Add ability to override itemStyles

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { CSSProperties, useEffect } from "react";
 import { makeDecorator, addons } from "@storybook/addons";
 
 import { PARAM_NAME, ADDON_ID, THEME_SET } from "./constants";
@@ -6,7 +6,7 @@ import { useSelectedThemes } from "./useSelectedThemes";
 
 const channel = addons.getChannel();
 
-const itemStyles: Record<string, string> = {
+const defaultItemStyles: CSSProperties = {
   display: `flex`,
   flex: `1`,
   alignItems: `center`,
@@ -64,7 +64,7 @@ export const withMultiTheme = makeDecorator({
               className={themeObject.class}
               style={{
                 backgroundColor: themeObject.backgroundColor,
-                ...itemStyles,
+                ...(themeObject.itemStyles || defaultItemStyles),
               }}
             >
 	      {themeObject.wrapperComponent && themeObject.wrapperComponent({children: getStory(context)})}

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -1,13 +1,20 @@
+import { CSSProperties } from "react";
+
 type Theme = {
-  name: string,
-  class: string,
-  iconColor: string,
-  backgroundColor: string,
-  selectedByDefault: true,
-  wrapperComponent: ({children}: {children: React.ReactNode}) => React.ReactNode
-}
+  name: string;
+  class: string;
+  iconColor: string;
+  backgroundColor: string;
+  selectedByDefault: true;
+  itemStyles?: CSSProperties;
+  wrapperComponent: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => React.ReactNode;
+};
 
 type MultiThemeParams = {
-  list?: Theme[],
-  disabled?: boolean
-}
+  list?: Theme[];
+  disabled?: boolean;
+};


### PR DESCRIPTION
## Issue

Currently `itemStyles` is hard-coded and cannot be overridden easily. 

At present this can only be achieved by setting a class on the wrapper and then overriding the CSS with an `!important` flag, and `itemStyles` currently take precedent over any conflicting class styles.

While the options provided are sensible defaults, it would be better to allow users to override these styles when initializing the object.

## Proposed solution

Add the ability to pass in an `itemStyles` object when setting up themes in `preview.js`. If provided those styles will be used on the outer wrapper, otherwise fallback to the defaults. 

I've tried to keep the naming consistent with what is present. Happy to update if needed. I also updated the styling type to only accept `CSSProperties`

